### PR TITLE
fix(close-button): use 'latest' as default type and 'post' as default id

### DIFF
--- a/src/pwa/components/PostBar/CloseButton.js
+++ b/src/pwa/components/PostBar/CloseButton.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { computed } from 'mobx';
@@ -60,9 +61,24 @@ CloseButton.defaultProps = {
 };
 
 export default inject(({ stores: { connection, settings } }) => {
-  const type = computed(() => connection.selectedItem.fromList.type).get();
-  const id = computed(() => connection.selectedItem.fromList.id).get();
-  const selectedContextIndex = computed(() => connection.selectedContext.index).get();
+  const type = computed(
+    () =>
+      connection.selectedItem.fromList
+        ? connection.selectedItem.fromList.type
+        : 'latest',
+  ).get();
+
+  const id = computed(
+    () =>
+      connection.selectedItem.fromList
+        ? connection.selectedItem.fromList.id
+        : 'post',
+  ).get();
+
+  const selectedContextIndex = computed(
+    () => connection.selectedContext.index,
+  ).get();
+
   const { menu } = settings.theme;
 
   return {


### PR DESCRIPTION
Fixes https://github.com/frontity/saturn-theme/issues/49