### PR TITLE
Fixes the margin top in Column

### DIFF
--- a/src/pwa/components/Contexts/Column.js
+++ b/src/pwa/components/Contexts/Column.js
@@ -146,7 +146,7 @@ class Column extends Component {
 
 export default inject(
   ({ stores: { connection, settings, build } }, { mstId }) => {
-    const featuredImage = settings.theme.featuredIamge || {};
+    const featuredImage = settings.theme.featuredImage || {};
     const postBar = settings.theme.postBar || {};
     const column = connection.selectedContext.getColumn(mstId);
 


### PR DESCRIPTION
The error was a typo when calling `settings.featuredImage`

fixes https://github.com/frontity/saturn-theme/issues/71