### PR TITLE
Correct the vertical position of the NotificationsSwitch's icon

### DIFF
--- a/src/pwa/components/NotificationsSwitch/index.js
+++ b/src/pwa/components/NotificationsSwitch/index.js
@@ -94,6 +94,7 @@ const StyledSwitch = styled(Switch)`
     color: #fff;
     font-size: 12px;
     position: absolute;
+    top: 0;
     left: 22px;
     height: 100%;
     display: flex;


### PR DESCRIPTION
Fixes https://github.com/frontity/saturn-theme/issues/146